### PR TITLE
fix: change height always out of viewport

### DIFF
--- a/src/components/ItemTable/ItemTable.css
+++ b/src/components/ItemTable/ItemTable.css
@@ -1,6 +1,6 @@
 .item-table {
     width: 48vw;
-    height: 76vh;
+    height: 72vh;
     margin: auto;
     overflow-y: auto;
     overflow-x: hidden;


### PR DESCRIPTION
`76vh` managed to always make the Gear page have a little bit of a pointless scroll (both of the item tables have scroll inside the box anyway) and `72vh` seems to fit quite nicely.