### PR TITLE
Update itemdata stats in MassUpdate

### DIFF
--- a/src/reducers/Items.js
+++ b/src/reducers/Items.js
@@ -545,6 +545,11 @@ const ItemsReducer = (state = INITIAL_STATE, action) => {
         }
 
         case MASSUPDATE: {
+            const newItemData = action.payload.data;
+            Object.getOwnPropertyNames(newItemData).forEach((itemid) => {
+                const item = newItemData[itemid];
+                update_level(item, item.level);
+            });
             return {
                 ...state,
                 itemdata: action.payload.data


### PR DESCRIPTION
`Reset Item Data` and `Load NGUSav.es JSON` failed to correctly update stats on the item data.

Steps to replicate using `Reset Item Data`:
1. Open gear optimizer in incognito / with no saved local data
2. Set Highest zone: The 2D Universe
3. Right click to edit level of (99) A Triangle. 
4. Change level to 0 and click Update
5. Click Reset Item Data
6. Click Optimize Gear

Current Behavior: Gear Optimizer recommends (89) A Comically Oversized Minute-Hand lvl 100 as the best weapon for Priority 1: Power

Expected Behavior: Gear Optimizer recommends (99) A Triangle lvl 100 as the best weapon for Priority 1: Power