### PR TITLE
Select import type dynamically based on file type

### DIFF
--- a/src/components/Content/Optimizer.js
+++ b/src/components/Content/Optimizer.js
@@ -119,7 +119,7 @@ class Optimizer extends Component {
                 <div className={this.props.className}>
                     <div className="content__container">
                         <div className='button-section' key='slots'>
-                            <ImportSaveForm rawSave={true} />
+                            <ImportSaveForm />
                             <button type="button" onClick={() => this.props.handleGo2Titan(8, 3, 5, 12)}>
                                 {'Titan 8 Preset'}
                             </button>

--- a/src/components/ImportSaveForm/ImportSaveForm.js
+++ b/src/components/ImportSaveForm/ImportSaveForm.js
@@ -4,7 +4,6 @@ import { Crement } from '../../actions/Crement';
 import { MassUpdate } from '../../actions/MassUpdateItems';
 import { Settings } from '../../actions/Settings';
 import { Deserializer } from './deserializeDotNet'
-import PropTypes from 'prop-types'
 
 // minimal boss for each zone, per difficulty
 const sadisticZones = [
@@ -58,9 +57,9 @@ const ImportSaveForm = (props) => {
 
     const inputElem = useRef(null);
 
-    const handleFileRead = (e) => {
+    const handleFileRead = (rawSave) => (e) => {
         let data
-        if (props.rawSave) {
+        if (rawSave) {
             const deserializer = Deserializer.fromFile(fileReader.result)
             deserializer.parse()
             /** @type Data */
@@ -268,7 +267,7 @@ const ImportSaveForm = (props) => {
         let file = e.target.files[0]
         e.target.value = null
         fileReader = new FileReader()
-        fileReader.onloadend = handleFileRead;
+        fileReader.onloadend = handleFileRead(file.type !== 'application/json');
         try {
             fileReader.readAsText(file)
         } catch{
@@ -280,13 +279,11 @@ const ImportSaveForm = (props) => {
     return (
         <div className="loadSave">
             <input ref={inputElem} style={{ display: "none" }} type='file' id='savefileloader' onChange={e => handleFilePick(e)} />
-            <button onClick={() => inputElem.current.click()}>{props.rawSave ? 'Load raw save file' : 'Load NGUSav.es JSON'}</button>
+            <button onClick={() => inputElem.current.click()}>Load raw save file or NGUSav.es JSON</button>
             <label>Disable unowned<input type="checkbox" checked={disableItems} onChange={() => { setDisableItems(!disableItems) }} /></label>
         </div>
     )
 }
 
-ImportSaveForm.propTypes = {
-    rawSave: PropTypes.bool
-}
+ImportSaveForm.propTypes = {}
 export default ImportSaveForm;


### PR DESCRIPTION
Right now the optimiser errors out silently if you try to load a json file as per past usage. This was a little confusing to me personally since I didn't notice the change in wording on the button and no error was shown. I'm not sure if the plan is to remove support for NGUSav.es completely eventually, but if not then for now it might be nicer to support both.

This PR re-enables loading save files using the NGUSav.es for anyone that might prefer it. The correct parser to use is selected based on the file type - specifically, if the type is JSON then the old NGUSav.es parser is used, otherwise the new raw parser is used.